### PR TITLE
Install screen & uninstall

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,9 +27,12 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     GOOS=linux GOARCH=arm64 go build -trimpath -ldflags="-w" -o bin/installer-linux-arm64
-RUN curl --fail --location --output cosmocc.zip \
+RUN mkdir -p /root/.cache/cosmocc
+RUN --mount=type=cache,target=/root/.cache/cosmocc \
+    curl --fail --location --output /root/.cache/cosmocc/cosmocc.zip \
     https://github.com/jart/cosmopolitan/releases/download/${COSMO_VERSION}/cosmocc-${COSMO_VERSION}.zip
-RUN unzip cosmocc.zip
+RUN --mount=type=cache,target=/root/.cache/cosmocc \
+    unzip /root/.cache/cosmocc/cosmocc.zip
 ENV PATH="$PATH:/installer/bin"
 # Not sure why we need the extra `#"`, but it seems to fix cosmo's bootstrap script.
 RUN apelink -V linux -S '#"' -o bin/installer-linux bin/installer-linux-*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM golang:1.21-alpine AS builder
+ARG COSMO_VERSION=3.9.2
 ENV CGO_ENABLED=0
 # Install necessary tools
 RUN apk update && \
@@ -22,7 +23,16 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 COPY installer/. .
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
-    GOOS=linux go build -trimpath -ldflags="-s -w" -o bin/installer-linux
+    GOOS=linux GOARCH=amd64 go build -trimpath -ldflags="-w" -o bin/installer-linux-amd64
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    GOOS=linux GOARCH=arm64 go build -trimpath -ldflags="-w" -o bin/installer-linux-arm64
+RUN curl --fail --location --output cosmocc.zip \
+    https://github.com/jart/cosmopolitan/releases/download/${COSMO_VERSION}/cosmocc-${COSMO_VERSION}.zip
+RUN unzip cosmocc.zip
+ENV PATH="$PATH:/installer/bin"
+# Not sure why we need the extra `#"`, but it seems to fix cosmo's bootstrap script.
+RUN apelink -V linux -S '#"' -o bin/installer-linux bin/installer-linux-*
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     GOOS=darwin GOARCH=amd64 go build -trimpath -ldflags="-s -w" -o bin/installer-darwin-amd64

--- a/installer/go.mod
+++ b/installer/go.mod
@@ -2,6 +2,9 @@ module github.com/rancher-sandbox/rd-open-webui-docker-ext/installer
 
 go 1.21.1
 
-require github.com/xenking/zipstream v1.0.1
+require (
+	github.com/xenking/zipstream v1.0.1
+	golang.org/x/sys v0.25.0
+)
 
 require github.com/klauspost/compress v1.13.6 // indirect

--- a/installer/go.sum
+++ b/installer/go.sum
@@ -2,3 +2,5 @@ github.com/klauspost/compress v1.13.6 h1:P76CopJELS0TiO2mebmnzgWaajssP/EszplttgQ
 github.com/klauspost/compress v1.13.6/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
 github.com/xenking/zipstream v1.0.1 h1:6LfcpXfxO9kAGi0a+2N5C0ZZ6jyG4XULPiogOM7gJBU=
 github.com/xenking/zipstream v1.0.1/go.mod h1:eV9JLfCRbQQUGcdipSENWByVYkPP8IAzuFiwBY+sChg=
+golang.org/x/sys v0.25.0 h1:r+8e+loiHxRqhXVl6ML1nO3l1+oFoWbnlu2Ehimmi34=
+golang.org/x/sys v0.25.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/metadata.json
+++ b/metadata.json
@@ -42,23 +42,18 @@
         ]
       }
     ],
-    "x-rd-install": {
-      "darwin": "installer",
-      "linux": "installer",
-      "windows": "installer.exe"
-    },
     "x-rd-uninstall": {
       "darwin": [
         "installer",
-        "-uninstall"
+        "-mode=uninstall"
       ],
       "linux": [
         "installer",
-        "-uninstall"
+        "-mode=uninstall"
       ],
       "windows": [
         "installer.exe",
-        "-uninstall"
+        "-mode=uninstall"
       ]
     }
   }

--- a/metadata.json
+++ b/metadata.json
@@ -41,6 +41,25 @@
           }
         ]
       }
-    ]
+    ],
+    "x-rd-install": {
+      "darwin": "installer",
+      "linux": "installer",
+      "windows": "installer.exe"
+    },
+    "x-rd-uninstall": {
+      "darwin": [
+        "installer",
+        "-uninstall"
+      ],
+      "linux": [
+        "installer",
+        "-uninstall"
+      ],
+      "windows": [
+        "installer.exe",
+        "-uninstall"
+      ]
+    }
   }
 }

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -16,8 +16,7 @@
         "axios": "^1.7.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-spinners": "^0.14.1",
-        "sudo-prompt": "^9.2.1"
+        "react-spinners": "^0.14.1"
       },
       "devDependencies": {
         "@docker/extension-api-client-types": "0.3.4",
@@ -6038,11 +6037,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
       "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw=="
-    },
-    "node_modules/sudo-prompt": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/sudo-prompt/-/sudo-prompt-9.2.1.tgz",
-      "integrity": "sha512-Mu7R0g4ig9TUuGSxJavny5Rv0egCEtpZRNMrZaYS1vxkiIxGiGUwoezU3LazIQ+KE04hTrTfNPgxU5gzi7F5Pw=="
     },
     "node_modules/supports-color": {
       "version": "5.5.0",

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,43 +1,84 @@
 import { useState, useEffect } from 'react';
-import FadeLoader from "react-spinners/FadeLoader";
 import { createDockerDesktopClient } from '@docker/extension-api-client';
 import WebpageFrame from './WebpageFrame';
-import './LoaderComponent.css';
+import InstallView from './InstallView';
+import LoadingView from './LoadingView';
 
-const client = createDockerDesktopClient();
-
-function useDockerDesktopClient() {
-  return client;
-}
+const ddClient = createDockerDesktopClient();
 
 export function App() {
-  const [loading, setLoading] = useState(true);
-  const ddClient = useDockerDesktopClient();
+  const [error, setError] = useState('');
+  const [installing, setInstalling] = useState(false);
+  const [installed, setInstalled] = useState(false);
+  const [started, setStarted] = useState(false);
+  const executable = `installer${ddClient.host.platform === 'win32' ? '.exe' : ''}`;
 
+  async function runInstaller(...args: string[]) {
+    const { host } = ddClient.extension;
+    if (!host) {
+      throw new Error(`Extension API does not have host`);
+    }
+    return await host.cli.exec(executable, args);
+  }
+
+  // On load, check if Ollama has already been installed.
   useEffect(() => {
-    const run = async () => {
-      let binary = "installer";
-      if (ddClient.host.platform === 'win32') {
-        binary += ".exe";
+    (async () => {
+      try {
+        const { stdout, stderr } = await runInstaller('--mode=locate');
+        stderr.trim() && console.error(stderr.trimEnd());
+        console.debug(`Got install location: ${stdout.trim() || '<none>'}`);
+        if (stdout.trim()) {
+          // Install location exists; just start ollama.
+          setInstalled(true);
+        }
+      } catch (ex) {
+        console.error(ex);
+        setError(`${ex}`);
       }
+    })();
+  });
 
-      await ddClient.extension.host?.cli.exec(binary, []);
-      setLoading(false);
-    };
-    run();
-  }, [ddClient]);
+  // Callback for <InstallView> to trigger the install.
+  function install(installLocation: string | undefined) {
+    (async () => {
+      try {
+        console.log(`Installing ollama to ${installLocation ?? '<default>'}...`);
+        setInstalling(true);
+        const { stdout, stderr } = await runInstaller('--mode=install', `--install-path=${installLocation ?? ''}`);
+        stderr.trim() && console.error(stderr.trimEnd());
+        stdout.trim() && console.debug(stdout.trimEnd());
+        setInstalled(true);
+      } catch (ex) {
+        console.error(ex);
+        setError(`${ex}`);
+      }
+    })();
+  }
+
+  // Trigger starting Ollama once it's been installed.
+  useEffect(() => {
+    (async () => {
+      try {
+        if (installed) {
+          const { stdout, stderr } = await runInstaller('--mode=start');
+          stderr.trim() && console.error(stderr.trimEnd());
+          stdout.trim() && console.debug(stdout.trimEnd());
+          setStarted(true);
+        }
+      } catch (ex) {
+        console.error(ex);
+        setError(`${ex}`);
+      }
+    })();
+  }, [installed]);
 
   return (
-    <>  
-        {loading ? 
-        <div className="loader-container">
-            <FadeLoader 
-              loading={loading}
-              color="#265277" 
-            />
-        </div> :
-        <WebpageFrame />
-        }
-    </>
+    <>{
+      !!error ? <div className="error">{error}</div> :
+        !installed && !installing ? <InstallView install={install} /> :
+          !started ? <LoadingView /> :
+            <WebpageFrame />
+    }</>
   );
 }

--- a/ui/src/InstallView.css
+++ b/ui/src/InstallView.css
@@ -1,0 +1,11 @@
+.install-wrapper {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.install-wrapper .options {
+    display: flex;
+    flex-direction: column;
+    margin: 2em;
+}

--- a/ui/src/InstallView.tsx
+++ b/ui/src/InstallView.tsx
@@ -1,0 +1,53 @@
+import { createDockerDesktopClient } from '@docker/extension-api-client';
+import { ChangeEvent, useState } from 'react';
+import './InstallView.css';
+
+const ddClient = createDockerDesktopClient();
+
+type InstallViewProps = {
+    install: (installLocation: string | undefined) => void;
+}
+
+export default function InstallView({ install }: InstallViewProps) {
+    const [usePath, setUsePath] = useState(false);
+    const [path, setPath] = useState('');
+
+    function onCheckboxStateChange(event: ChangeEvent<HTMLInputElement>) {
+        setUsePath(event.target.checked);
+    }
+
+    async function browse() {
+        try {
+            const { filePaths } = await ddClient.desktopUI.dialog.showOpenDialog({ properties: ['openDirectory', 'createDirectory', 'promptToCreate', 'dontAddToRecent'] });
+            const selectedPath = filePaths.shift();
+            if (selectedPath) {
+                setPath(selectedPath);
+            }
+        } catch (ex) {
+            console.error(ex);
+            setUsePath(false);
+        }
+    }
+
+    function isInputsValid() {
+        // Either we don't use path, or path is not empty.
+        return !usePath || !!path;
+    }
+
+    function triggerInstall() {
+        install(usePath ? path : undefined);
+    }
+
+    return <div className="install-wrapper">
+        <h2>Ollama needs to be installed</h2>
+        <div className="options">
+            <label>
+                <input type="checkbox" checked={usePath} onChange={onCheckboxStateChange} />
+                Install Ollama to custom location
+            </label>
+            <input type="text" readOnly value={path} disabled={!usePath} />
+            <button onClick={browse} disabled={!usePath}>Browse...</button>
+        </div>
+        <button onClick={triggerInstall} disabled={!isInputsValid}>Install</button>
+    </div>;
+}

--- a/ui/src/LoadingView.tsx
+++ b/ui/src/LoadingView.tsx
@@ -1,0 +1,8 @@
+import { FadeLoader } from "react-spinners";
+import './LoaderComponent.css';
+
+export default function LoadingView() {
+    return <div className="loading-container">
+        <FadeLoader color="#265277" />
+    </div>;
+}

--- a/ui/src/WebpageFrame.tsx
+++ b/ui/src/WebpageFrame.tsx
@@ -5,8 +5,11 @@ const WebpageFrame = () => {
     <iframe
       src="http://localhost:3000"
       style={{
+        position: 'absolute',
+        left: '0',
+        top: '0',
         width: '100%',
-        height: '100vh', 
+        height: '100%',
         border: 'none', 
       }}
     />

--- a/ui/src/main.css
+++ b/ui/src/main.css
@@ -1,0 +1,7 @@
+body {
+    /* Center everything */
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100vh;
+}

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -2,16 +2,15 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import CssBaseline from "@mui/material/CssBaseline";
 import { DockerMuiThemeProvider } from "@docker/docker-mui-theme";
+import './main.css';
 
 import { App } from './App';
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>
-    {/*
-      If you eject from MUI (which we don't recommend!), you should add
-      the `dockerDesktopTheme` class to your root <html> element to get
-      some minimal Docker theming.
-    */}
+    <DockerMuiThemeProvider>
+      <CssBaseline />
       <App />
+    </DockerMuiThemeProvider>
   </React.StrictMode>
 );


### PR DESCRIPTION
This adds a screen for installing Ollama (if we don't detect it in some fixed locations), and uninstalls Ollama (if we installed it) when the extension is uninstalled.

This does not currently remove any user data (e.g. models) on uninstall; we will need to sort out what we want there first.