### PR TITLE
Add workflow to build the extension and push to GHCR

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,30 @@
+name: Build
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
+    - uses: docker/setup-qemu-action@v3
+      with:
+        platforms: amd64,arm64
+    - uses: docker/setup-buildx-action@v3
+      with:
+        platforms: |
+          linux/amd64
+          linux/arm64
+    - uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - uses: docker/build-push-action@v6
+      with:
+        platforms: |
+          linux/amd64
+          linux/arm64
+        push: true
+        tags: |
+          ghcr.io/${{ github.repository }}:${{ github.ref == 'refs/heads/main' && 'latest' || github.sha }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,29 +23,10 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 COPY installer/. .
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
-    GOOS=linux GOARCH=amd64 go build -trimpath -ldflags="-w" -o bin/installer-linux-amd64
+    GOOS=linux go build -trimpath -ldflags="-s -w" -o bin/installer-linux
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
-    GOOS=linux GOARCH=arm64 go build -trimpath -ldflags="-w" -o bin/installer-linux-arm64
-RUN mkdir -p /root/.cache/cosmocc
-RUN --mount=type=cache,target=/root/.cache/cosmocc \
-    curl --fail --location --output /root/.cache/cosmocc/cosmocc.zip \
-    https://github.com/jart/cosmopolitan/releases/download/${COSMO_VERSION}/cosmocc-${COSMO_VERSION}.zip
-RUN --mount=type=cache,target=/root/.cache/cosmocc \
-    unzip /root/.cache/cosmocc/cosmocc.zip
-ENV PATH="$PATH:/installer/bin"
-# Not sure why we need the extra `#"`, but it seems to fix cosmo's bootstrap script.
-RUN apelink -V linux -S '#"' -o bin/installer-linux bin/installer-linux-*
-RUN --mount=type=cache,target=/go/pkg/mod \
-    --mount=type=cache,target=/root/.cache/go-build \
-    GOOS=darwin GOARCH=amd64 go build -trimpath -ldflags="-s -w" -o bin/installer-darwin-amd64
-RUN --mount=type=cache,target=/go/pkg/mod \
-    --mount=type=cache,target=/root/.cache/go-build \
-    GOOS=darwin GOARCH=arm64 go build -trimpath -ldflags="-s -w" -o bin/installer-darwin-arm64
-RUN --mount=type=cache,target=/go/pkg/mod \
-    --mount=type=cache,target=/root/.cache/go-build \
-    go run github.com/randall77/makefat@7ddd0e42c8442593c87c1705a5545099604008e5 \
-    bin/installer-darwin bin/installer-darwin-*
+    GOOS=darwin go build -trimpath -ldflags="-s -w" -o bin/installer-darwin
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     GOOS=windows go build -trimpath -ldflags="-s -w" -o bin/installer-windows.exe

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ INFO_COLOR = \033[0;36m
 NO_COLOR   = \033[m
 
 build-extension: ## Build service image to be deployed as a desktop extension
-	docker build --tag=$(IMAGE):$(TAG) .
+	docker build --platform linux/amd64,linux/arm64 --tag=$(IMAGE):$(TAG) .
 
 install-extension: build-extension ## Install the extension
 	docker extension install $(IMAGE):$(TAG)


### PR DESCRIPTION
Because apelink doesn't seem to work on CI (binfmt_misc issues?), build multi-platform docker images instead.

Sample images: https://github.com/mook-as/rd-open-webui-docker-ext/pkgs/container/rd-open-webui-docker-ext
Sample run: https://github.com/mook-as/rd-open-webui-docker-ext/actions/runs/11149097003

Fixes #7