### PR TITLE
Remove installation path selection

### DIFF
--- a/installer/main_darwin.go
+++ b/installer/main_darwin.go
@@ -24,7 +24,7 @@ const (
 func findExecutable(ctx context.Context) string {
 	var potentialLocations []string
 
-	if installLocation, err := getInstallLocation(ctx); err == nil {
+	if installLocation, err := getDefaultInstallLocation(ctx); err == nil {
 		potentialLocations = append(potentialLocations, installLocation)
 	}
 
@@ -107,7 +107,7 @@ func installOllama(ctx context.Context, release, executablePath string) (string,
 }
 
 func uninstallOllama(ctx context.Context) error {
-	installPath, err := getInstallLocation(ctx)
+	installPath, err := getDefaultInstallLocation(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to find ollama install: %w", err)
 	}

--- a/installer/main_linux.go
+++ b/installer/main_linux.go
@@ -20,7 +20,7 @@ import (
 func findExecutable(ctx context.Context) string {
 	var potentialLocations []string
 
-	if installLocation, err := getInstallLocation(ctx); err == nil {
+	if installLocation, err := getDefaultInstallLocation(ctx); err == nil {
 		executablePath := filepath.Join(installLocation, "bin", "ollama")
 		potentialLocations = append(potentialLocations, executablePath)
 	}
@@ -149,7 +149,7 @@ func installOllama(ctx context.Context, release, installPath string) (string, er
 }
 
 func uninstallOllama(ctx context.Context) error {
-	installDir, err := getInstallLocation(ctx)
+	installDir, err := getDefaultInstallLocation(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to find ollama install: %w", err)
 	}

--- a/installer/main_windows.go
+++ b/installer/main_windows.go
@@ -22,7 +22,7 @@ import (
 func findExecutable(ctx context.Context) string {
 	var potentialLocations []string
 
-	if installLocation, err := getInstallLocation(ctx); err == nil {
+	if installLocation, err := getDefaultInstallLocation(ctx); err == nil {
 		executablePath := filepath.Join(installLocation, "ollama.exe")
 		potentialLocations = append(potentialLocations, executablePath)
 	}
@@ -133,7 +133,7 @@ func installOllama(ctx context.Context, release, installPath string) (string, er
 }
 
 func uninstallOllama(ctx context.Context) error {
-	installDir, err := getInstallLocation(ctx)
+	installDir, err := getDefaultInstallLocation(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to find ollama install: %w", err)
 	}

--- a/metadata.json
+++ b/metadata.json
@@ -42,6 +42,20 @@
         ]
       }
     ],
+    "x-rd-install": {
+      "darwin": [
+        "installer",
+        "-mode=install"
+      ],
+      "linux": [
+        "installer",
+        "-mode=install"
+      ],
+      "windows": [
+        "installer.exe",
+        "-mode=install"
+      ]
+    },
     "x-rd-uninstall": {
       "darwin": [
         "installer",

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -25,10 +25,10 @@ export function App() {
   useEffect(() => {
     (async () => {
       try {
-        const { stdout, stderr } = await runInstaller('--mode=locate');
+        const { stdout, stderr } = await runInstaller('--mode=check');
         stderr.trim() && console.error(stderr.trimEnd());
-        console.debug(`Got install location: ${stdout.trim() || '<none>'}`);
-        if (stdout.trim()) {
+        console.debug(`Installation check: ${stdout.trim()}`);
+        if (stdout.trim() === 'true') {
           // Install location exists; just start ollama.
           setInstalled(true);
         }
@@ -40,12 +40,12 @@ export function App() {
   });
 
   // Callback for <InstallView> to trigger the install.
-  function install(installLocation: string | undefined) {
+  function install() {
     (async () => {
       try {
-        console.log(`Installing ollama to ${installLocation ?? '<default>'}...`);
+        console.log(`Installing ollama to...`);
         setInstalling(true);
-        const { stdout, stderr } = await runInstaller('--mode=install', `--install-path=${installLocation ?? ''}`);
+        const { stdout, stderr } = await runInstaller('--mode=install');
         stderr.trim() && console.error(stderr.trimEnd());
         stdout.trim() && console.debug(stdout.trimEnd());
         setInstalled(true);

--- a/ui/src/InstallView.css
+++ b/ui/src/InstallView.css
@@ -3,9 +3,3 @@
     flex-direction: column;
     align-items: center;
 }
-
-.install-wrapper .options {
-    display: flex;
-    flex-direction: column;
-    margin: 2em;
-}

--- a/ui/src/InstallView.tsx
+++ b/ui/src/InstallView.tsx
@@ -1,53 +1,12 @@
-import { createDockerDesktopClient } from '@docker/extension-api-client';
-import { ChangeEvent, useState } from 'react';
 import './InstallView.css';
 
-const ddClient = createDockerDesktopClient();
-
 type InstallViewProps = {
-    install: (installLocation: string | undefined) => void;
+    install: () => void;
 }
 
 export default function InstallView({ install }: InstallViewProps) {
-    const [usePath, setUsePath] = useState(false);
-    const [path, setPath] = useState('');
-
-    function onCheckboxStateChange(event: ChangeEvent<HTMLInputElement>) {
-        setUsePath(event.target.checked);
-    }
-
-    async function browse() {
-        try {
-            const { filePaths } = await ddClient.desktopUI.dialog.showOpenDialog({ properties: ['openDirectory', 'createDirectory', 'promptToCreate', 'dontAddToRecent'] });
-            const selectedPath = filePaths.shift();
-            if (selectedPath) {
-                setPath(selectedPath);
-            }
-        } catch (ex) {
-            console.error(ex);
-            setUsePath(false);
-        }
-    }
-
-    function isInputsValid() {
-        // Either we don't use path, or path is not empty.
-        return !usePath || !!path;
-    }
-
-    function triggerInstall() {
-        install(usePath ? path : undefined);
-    }
-
     return <div className="install-wrapper">
         <h2>Ollama needs to be installed</h2>
-        <div className="options">
-            <label>
-                <input type="checkbox" checked={usePath} onChange={onCheckboxStateChange} />
-                Install Ollama to custom location
-            </label>
-            <input type="text" readOnly value={path} disabled={!usePath} />
-            <button onClick={browse} disabled={!usePath}>Browse...</button>
-        </div>
-        <button onClick={triggerInstall} disabled={!isInputsValid}>Install</button>
+        <button onClick={install}>Install</button>
     </div>;
 }


### PR DESCRIPTION
Drop the ability to select the installation path again, and just install it into the default location (where the extension lives) on extension install. The install screen still remains (with just a button) in case things go wrong; that way we can still trigger a fallback install if the backend ends up missing.