### PR TITLE
Installer: Add shutdown

### DIFF
--- a/installer/main.go
+++ b/installer/main.go
@@ -100,7 +100,7 @@ func install(ctx context.Context) error {
 	if isRunning {
 		return nil
 	}
-	executablePath := findExecutable(ctx)
+	executablePath := findExecutable(ctx, false)
 	if executablePath == "" {
 		// If a previous executable is not found, install it to the default
 		// location.
@@ -212,7 +212,7 @@ func checkInstall(ctx context.Context) error {
 		}
 		return nil
 	}
-	location := findExecutable(ctx)
+	location := findExecutable(ctx, false)
 	if location != "" {
 		if _, err := os.Stat(location); err == nil {
 			if _, err = fmt.Println("true"); err != nil {
@@ -234,7 +234,7 @@ func startOllama(ctx context.Context) error {
 		return nil
 	}
 
-	executablePath := findExecutable(ctx)
+	executablePath := findExecutable(ctx, false)
 	if executablePath == "" {
 		return fmt.Errorf("failed to find ollama executable; was it installed?")
 	}
@@ -274,7 +274,7 @@ func startOllama(ctx context.Context) error {
 }
 
 func shutdownOllama(ctx context.Context) error {
-	executablePath := findExecutable(ctx)
+	executablePath := findExecutable(ctx, true)
 	if executablePath == "" {
 		// When shutting down, it is not an error if it was not found.
 		return nil

--- a/installer/main_darwin.go
+++ b/installer/main_darwin.go
@@ -19,23 +19,25 @@ const (
 	KERN_PROCARGS = 38
 )
 
-// Find an existing install of ollama; this may be externally installed.
-// If not found, returns empty string.
-func findExecutable(ctx context.Context) string {
+// Find an existing install of ollama; if defaultOnly is false, this may include
+// externally installed copies of ollama.  If not found, returns empty string.
+func findExecutable(ctx context.Context, defaultOnly bool) string {
 	var potentialLocations []string
 
 	if installLocation, err := getDefaultInstallLocation(ctx); err == nil {
 		potentialLocations = append(potentialLocations, installLocation)
 	}
 
-	potentialLocations = append(potentialLocations,
-		"/usr/local/bin/ollama",
-		"/Applications/Ollama.app/Contents/Resources/ollama",
-	)
-
-	if homeDir, err := os.UserHomeDir(); err == nil {
+	if !defaultOnly {
 		potentialLocations = append(potentialLocations,
-			filepath.Join(homeDir, "Applications/Ollama.app/Contents/Resources/ollama"))
+			"/usr/local/bin/ollama",
+			"/Applications/Ollama.app/Contents/Resources/ollama",
+		)
+
+		if homeDir, err := os.UserHomeDir(); err == nil {
+			potentialLocations = append(potentialLocations,
+				filepath.Join(homeDir, "Applications/Ollama.app/Contents/Resources/ollama"))
+		}
 	}
 
 	for _, location := range potentialLocations {

--- a/installer/main_linux.go
+++ b/installer/main_linux.go
@@ -17,7 +17,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func findExecutable(ctx context.Context) string {
+func findExecutable(ctx context.Context, defaultOnly bool) string {
 	var potentialLocations []string
 
 	if installLocation, err := getDefaultInstallLocation(ctx); err == nil {
@@ -25,7 +25,9 @@ func findExecutable(ctx context.Context) string {
 		potentialLocations = append(potentialLocations, executablePath)
 	}
 
-	potentialLocations = append(potentialLocations, "/usr/local/bin/ollama")
+	if !defaultOnly {
+		potentialLocations = append(potentialLocations, "/usr/local/bin/ollama")
+	}
 
 	for _, location := range potentialLocations {
 		if _, err := os.Stat(location); err == nil {

--- a/installer/main_windows.go
+++ b/installer/main_windows.go
@@ -19,7 +19,7 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-func findExecutable(ctx context.Context) string {
+func findExecutable(ctx context.Context, defaultOnly bool) string {
 	var potentialLocations []string
 
 	if installLocation, err := getDefaultInstallLocation(ctx); err == nil {
@@ -27,16 +27,18 @@ func findExecutable(ctx context.Context) string {
 		potentialLocations = append(potentialLocations, executablePath)
 	}
 
-	programsDir, err := windows.KnownFolderPath(windows.FOLDERID_UserProgramFiles, windows.KF_FLAG_DEFAULT)
-	if err == nil {
-		// See Ollama setup source code:
-		// https://github.com/ollama/ollama/blob/03608cb46ecdccaf8c340c9390626a9d8fcc3c6b/app/ollama.iss#L33
-		// https://github.com/ollama/ollama/blob/03608cb46ecdccaf8c340c9390626a9d8fcc3c6b/app/ollama.iss#L92
-		potentialLocations = append(potentialLocations, filepath.Join(programsDir, "Ollama", "ollama.exe"))
+	if !defaultOnly {
+		programsDir, err := windows.KnownFolderPath(windows.FOLDERID_UserProgramFiles, windows.KF_FLAG_DEFAULT)
+		if err == nil {
+			// See Ollama setup source code:
+			// https://github.com/ollama/ollama/blob/03608cb46ecdccaf8c340c9390626a9d8fcc3c6b/app/ollama.iss#L33
+			// https://github.com/ollama/ollama/blob/03608cb46ecdccaf8c340c9390626a9d8fcc3c6b/app/ollama.iss#L92
+			potentialLocations = append(potentialLocations, filepath.Join(programsDir, "Ollama", "ollama.exe"))
+		}
 	}
 
 	for _, location := range potentialLocations {
-		if _, err = os.Stat(location); err == nil {
+		if _, err := os.Stat(location); err == nil {
 			// Found an existing ollama
 			return location
 		}

--- a/metadata.json
+++ b/metadata.json
@@ -69,6 +69,20 @@
         "installer.exe",
         "-mode=uninstall"
       ]
+    },
+    "x-rd-shutdown": {
+      "darwin": [
+        "installer",
+        "-mode=shutdown"
+      ],
+      "linux": [
+        "installer",
+        "-mode=shutdown"
+      ],
+      "windows": [
+        "installer.exe",
+        "-mode=shutdown"
+      ]
     }
   }
 }


### PR DESCRIPTION
This shuts down the ollama server (that we spawn) on demand.

This fixes part 1 of rancher-sandbox/rancher-desktop-rdx-open-webui#4.
Part 2 already happens (we're reusing the code from that here).
Part 3 needs to be done in Rancher Desktop.