### PR TITLE
CI: Add release tags

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,6 +7,22 @@ jobs:
     - uses: actions/checkout@v4
       with:
         persist-credentials: false
+    - id: tags
+      name: Calculate tags
+      shell: bash
+      run: |
+        prefix=ghcr.io/${{ github.repository }}
+        echo "TAGS<<##" >> "$GITHUB_OUTPUT"
+        ref=${{ github.ref }}
+        case "$ref" in
+          refs/heads/main)
+            echo "$prefix:latest" >> "$GITHUB_OUTPUT";;
+          refs/tags/v[0-9]*)
+            echo "$prefix:${ref#refs/tags/}" >> "$GITHUB_OUTPUT";;
+          *)
+            echo "$prefix:${{ github.sha }}" >> "$GITHUB_OUTPUT";;
+        esac
+        echo "##" >> "$GITHUB_OUTPUT"
     - uses: docker/setup-qemu-action@v3
       with:
         platforms: amd64,arm64
@@ -26,5 +42,4 @@ jobs:
           linux/amd64
           linux/arm64
         push: true
-        tags: |
-          ghcr.io/${{ github.repository }}:${{ github.ref == 'refs/heads/main' && 'latest' || github.sha }}
+        tags: ${{ steps.tags.outputs.TAGS }}


### PR DESCRIPTION
This tags the the built image as `latest` if it came off the `main` branch, or the tag (e.g. `v0.0.0`) if it was a tag starting with `v` followed by a number; otherwise, do as before and use the commit hash.

Note that this has nothing to do with GitHub releases, just git tags.

Fixes #13 

---
Sample runs:
- https://github.com/mook-as/rd-open-webui-docker-ext/actions/runs/11245265290/job/31264942826
- https://github.com/mook-as/rd-open-webui-docker-ext/actions/runs/11245265954/job/31264944416
- https://github.com/mook-as/rd-open-webui-docker-ext/actions/runs/11245267381/job/31264948593

(They're all the same commit, with different names.)