### PR TITLE
Update cookie, port and default web search option

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,13 +11,15 @@ services:
   open-webui:
     image: ghcr.io/open-webui/open-webui:main
     ports:
-      - "3000:8080"
+      - "11500:8080"
     volumes:
       - open-webui:/app/backend/data
     environment:
       - WEBUI_AUTH=False
+      - WEBUI_SESSION_COOKIE_SAME_SITE=None
+      - WEBUI_SESSION_COOKIE_SECURE=True
       - ENABLE_RAG_WEB_SEARCH=True
-      - RAG_WEB_SEARCH_ENGINE=duckduckgo
+      - RAG_WEB_SEARCH_ENGINE=searxng
       - DEFAULT_MODELS=tinyllama
       - SEARXNG_QUERY_URL=http://host.docker.internal:8080
     restart: always

--- a/ui/src/WebpageFrame.tsx
+++ b/ui/src/WebpageFrame.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 const WebpageFrame = () => {
   return (
     <iframe
-      src="http://localhost:3000"
+      src="http://localhost:11500"
       style={{
         position: 'absolute',
         left: '0',


### PR DESCRIPTION
Fixes #17 , #19 , #20 

- Set `WEBUI_SESSION_COOKIE_SAME_SITE=None` and `WEBUI_SESSION_COOKIE_SECURE=True` to allow saving the open-webui's token in a cross origin setup
- Changes the open-webui port to a hopefully not so common `11500`
- Set the default web search option as searxng as it provided better, relevant results in my testing