### PR TITLE
Avoid showing Ollama install screen when not required

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -8,6 +8,7 @@ const ddClient = createDockerDesktopClient();
 
 export function App() {
   const [error, setError] = useState('');
+  const [checked, setChecked] = useState(false);
   const [installing, setInstalling] = useState(false);
   const [installed, setInstalled] = useState(false);
   const [started, setStarted] = useState(false);
@@ -32,12 +33,13 @@ export function App() {
           // Install location exists; just start ollama.
           setInstalled(true);
         }
+        setChecked(true);
       } catch (ex) {
         console.error(ex);
         setError(`${ex}`);
       }
     })();
-  });
+  }, []);
 
   // Callback for <InstallView> to trigger the install.
   function install() {
@@ -76,7 +78,7 @@ export function App() {
   return (
     <>{
       !!error ? <div className="error">{error}</div> :
-        !installed && !installing ? <InstallView install={install} /> :
+        !installed && !installing && checked ? <InstallView install={install} /> :
           !started ? <LoadingView /> :
             <WebpageFrame />
     }</>

--- a/ui/src/WebpageFrame.tsx
+++ b/ui/src/WebpageFrame.tsx
@@ -1,18 +1,34 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
+import LoadingView from './LoadingView';
 
 const WebpageFrame = () => {
+  const [hideIframeView, setHideIframeView] = useState(true);
+
+  useEffect(() => {
+    const showIframeViewAfterInterval = async (time: number) => {
+      await new Promise(resolve => setTimeout(resolve, time));
+      setHideIframeView(false);
+    };
+    showIframeViewAfterInterval(1000);
+  }, []);
+
   return (
-    <iframe
-      src="http://localhost:11500"
-      style={{
-        position: 'absolute',
-        left: '0',
-        top: '0',
-        width: '100%',
-        height: '100%',
-        border: 'none', 
-      }}
-    />
+    <>
+      {hideIframeView && <LoadingView />}
+      <iframe
+        src="http://localhost:11500"
+        style={{
+          position: 'absolute',
+          left: '0',
+          top: '0',
+          width: '100%',
+          height: '100%',
+          border: 'none',
+          opacity: hideIframeView ? 0 : 1,
+          transition: 'opacity 0.5s ease-in-out'        
+        }}
+      />
+    </>
   );
 };
 


### PR DESCRIPTION
Fixes #15 

The PR eliminates showing the Ollama install screen when not required. The extension loading is still not as smooth as one would like to have but at least one less screen than earlier.